### PR TITLE
Fix compilation on UNIX-like systems

### DIFF
--- a/src/headertest.cpp
+++ b/src/headertest.cpp
@@ -1,1 +1,1 @@
-#include <luabind\class.hpp>
+#include <luabind/class.hpp>


### PR DESCRIPTION
Never use '\' slash in paths, '/' slash works on every platform fine. Even instead C:\xxx\yyy\ will more convenient to use C:/xxx/yyy - will work too
